### PR TITLE
fix(flake): shellHook don't fail if symlink exists

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -60,8 +60,8 @@
           devShells.default = pkgs.mkShell {
             inputsFrom = [ site ];
             shellHook = ''
-              mkdir -p themes
-              ln -sn ${theme} themes/${themeName}
+              mkdir --parents themes
+              ln --symbolic --no-dereference --force ${theme} themes/${themeName}
             '';
           };
         };


### PR DESCRIPTION
Replace it instead.
